### PR TITLE
Change orderby on single to proper properties

### DIFF
--- a/src/mongodb-extension.js
+++ b/src/mongodb-extension.js
@@ -8,7 +8,7 @@ function single(query, _defaultToNull) {
         this.where(query);
     }
     return this.take(2)
-        .orderBy([{}])
+        .orderBy("_updatedDate")
         .execute()
         .then((docs) => {
             if (docs.count === 0) {


### PR DESCRIPTION
Mongodb on cosmosdb azure does not support strange query that cannot be executed. It will simply return empty query. On mongodb bluemix, the strange query is simply not executed.